### PR TITLE
Word markdown add-in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# Word Markdown VSTO Add-in
+
+This repository contains the source code scaffold for a Microsoft Word VSTO add-in that provides a Markdown editor/preview pane, Ribbon commands, and basic import/export of `.md` files.
+
+The add-in implements:
+- Task Pane with WebView2-based split view (editor + live preview)
+- Markdown → HTML rendering via Markdig (C#)
+- Prism.js syntax highlighting, MathJax, Mermaid, DOMPurify (client-side)
+- Ribbon (XML) with buttons for common Markdown actions (bold, italic, lists, code block, link, image, etc.)
+- Open/Save `.md` with UTF-8
+- Storage of Markdown source in the Word document `CustomXMLPart` (namespace `urn:markdown/source`)
+
+Note: Building and running a VSTO add-in requires Windows and Visual Studio with Office Developer Tools.
+
+## Prerequisites (on Windows)
+- Microsoft Word 2016/2019/2021/365 (x64 recommended)
+- Windows 10/11
+- Visual Studio 2022 (Community/Pro/Enterprise)
+  - Workload: Office/SharePoint development
+- .NET Framework 4.8 Developer Pack
+- WebView2 Runtime ( Evergreen )
+- Optional: Pandoc (for DOCX→MD conversion beyond the built-in scope)
+
+## How to use this code in Visual Studio (recommended path)
+1. Open Visual Studio on Windows.
+2. Create a new project: "Word VSTO Add-in" (.NET Framework). Name it `WordMarkdownAddIn`.
+3. Close the newly created files `ThisAddIn.cs` and the default Ribbon if any.
+4. In Solution Explorer:
+   - Add existing items from this repo into your project:
+     - `WordMarkdownAddIn/ThisAddIn.cs`
+     - `WordMarkdownAddIn/ThisAddIn.Designer.cs`
+     - `WordMarkdownAddIn/Ribbon.cs`
+     - `WordMarkdownAddIn/Controls/TaskPaneControl.cs`
+     - `WordMarkdownAddIn/Services/MarkdownRenderService.cs`
+     - `WordMarkdownAddIn/Services/DocumentSyncService.cs`
+     - `WordMarkdownAddIn/Properties/AssemblyInfo.cs` (optional override)
+   - Ensure the namespaces match your project root namespace (default is `WordMarkdownAddIn`).
+5. Add NuGet packages to the VSTO project:
+   - `Markdig` (latest stable)
+   - `Microsoft.Web.WebView2` (latest stable)
+   - `NLog` (optional; not required for the scaffold)
+   - `Microsoft.Office.Interop.Word` (if not already referenced by the VSTO template)
+6. Build the solution. Visual Studio will generate the necessary VSTO artifacts.
+7. Start debugging (F5). Word will launch with the add-in loaded. A new tab `Markdown` should appear on the Ribbon.
+
+## Features implemented in the scaffold
+- Task Pane titled `Markdown` shown by default on startup
+- Editor (textarea) on the left, live preview on the right (WebView2)
+- Markdown rendered via Markdig pipeline in .NET
+- Prism.js highlighting, Mermaid diagrams, MathJax equations, sanitized with DOMPurify
+- Ribbon buttons for:
+  - Toggle Pane, Open `.md`, Save `.md`
+  - Bold, Italic, Strikethrough, Inline Code
+  - Headings (H1), Bullet list, Numbered list, Checkbox, Table, Link, Image, Horizontal rule
+  - Code block (with language), Mermaid block, Math block
+- Markdown is stored in the active Word document inside a `CustomXMLPart` with namespace `urn:markdown/source`
+
+## Notes
+- The scaffold uses a simple textarea editor for reliability. You can replace it with Monaco editor later if desired.
+- Mermaid rendering converts code blocks with language `mermaid` into `<div class="mermaid">` before initializing Mermaid.
+- MathJax renders inline `$...$` and display `$$...$$` math. Markdig math extension is enabled.
+- HTML blocks in Markdown are sanitized in the preview for safety (DOMPurify). You can adjust the whitelist inside `preview` script.
+
+## Known limitations
+- The project file (`.csproj`) for VSTO is not included; create the project via Visual Studio template and add these sources.
+- Some advanced round-trip conversions Word↔Markdown require Pandoc and are out of scope of this scaffold.
+
+## Uninstall / Clean
+- Close all Word instances before rebuilding.
+- Visual Studio manages registration/unregistration of the add-in during Debug runs.
+
+## Troubleshooting
+- If the Task Pane is blank, ensure WebView2 Runtime is installed.
+- If the Ribbon is missing, confirm the add-in is loaded under File → Options → Add-ins → COM Add-ins.
+- If build fails due to references, reinstall the Office Developer Tools workload and verify PiA references.

--- a/WordMarkdownAddIn/Controls/TaskPaneControl.cs
+++ b/WordMarkdownAddIn/Controls/TaskPaneControl.cs
@@ -1,0 +1,322 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.WinForms;
+
+namespace WordMarkdownAddIn.Controls
+{
+	public class TaskPaneControl : UserControl
+	{
+		private readonly WebView2 _webView;
+		private readonly Services.MarkdownRenderService _renderer;
+		private string _latestMarkdown = string.Empty;
+		private bool _coreReady = false;
+
+		public TaskPaneControl()
+		{
+			_renderer = new Services.MarkdownRenderService();
+			_webView = new WebView2
+			{
+				Dock = DockStyle.Fill
+			};
+			Controls.Add(_webView);
+			Load += OnLoadAsync;
+		}
+
+		private async void OnLoadAsync(object sender, EventArgs e)
+		{
+			try
+			{
+				await _webView.EnsureCoreWebView2Async();
+				_coreReady = true;
+				_webView.CoreWebView2.WebMessageReceived += CoreWebView2_WebMessageReceived;
+				_webView.CoreWebView2.Settings.AreDevToolsEnabled = true;
+				_webView.CoreWebView2.Settings.IsStatusBarEnabled = false;
+				_webView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = true;
+
+				_webView.NavigateToString(BuildHtmlShell());
+			}
+			catch (Exception ex)
+			{
+				MessageBox.Show($"WebView2 initialization failed: {ex.Message}");
+			}
+		}
+
+		private void CoreWebView2_WebMessageReceived(object sender, CoreWebView2WebMessageReceivedEventArgs e)
+		{
+			try
+			{
+				var json = e.TryGetWebMessageAsString();
+				if (string.IsNullOrEmpty(json)) return;
+				// very simple protocol: type|payloadBase64
+				var parts = json.Split(new[] { '|' }, 2);
+				if (parts.Length != 2) return;
+				var type = parts[0];
+				var payload = Encoding.UTF8.GetString(Convert.FromBase64String(parts[1]));
+
+				if (type == "mdChanged")
+				{
+					_latestMarkdown = payload;
+					var html = _renderer.RenderToHtml(payload);
+					PostRenderHtml(html);
+				}
+			}
+			catch { /* ignore malformed messages */ }
+		}
+
+		private void PostRenderHtml(string html)
+		{
+			if (!_coreReady) return;
+			var b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(html));
+			_webView.CoreWebView2.ExecuteScriptAsync($"window.renderHtml(atob('{b64}'));void(0);");
+		}
+
+		public void SetMarkdown(string markdown)
+		{
+			_latestMarkdown = markdown ?? string.Empty;
+			if (!_coreReady) return;
+			var b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(_latestMarkdown));
+			_webView.CoreWebView2.ExecuteScriptAsync($"window.editorSetValue(atob('{b64}'));void(0);");
+		}
+
+		public string GetCachedMarkdown() => _latestMarkdown;
+
+		public async Task<string> GetMarkdownAsync()
+		{
+			// Return cached value (kept in sync by mdChanged). Fallback to JS query if needed.
+			if (!string.IsNullOrEmpty(_latestMarkdown)) return _latestMarkdown;
+			if (_coreReady)
+			{
+				var js = await _webView.CoreWebView2.ExecuteScriptAsync("window.editorGetValue()");
+				return UnquoteJsonString(js);
+			}
+			return string.Empty;
+		}
+
+		private static string UnquoteJsonString(string jsonQuoted)
+		{
+			if (string.IsNullOrEmpty(jsonQuoted)) return string.Empty;
+			var s = jsonQuoted;
+			if (s.StartsWith("\"") && s.EndsWith("\"")) s = s.Substring(1, s.Length - 2);
+			s = s.Replace("\\n", "\n").Replace("\\r", "\r").Replace("\\t", "\t").Replace("\\\"", "\"").Replace("\\\\", "\\");
+			return s;
+		}
+
+		public void InsertInline(string prefix, string suffix)
+		{
+			if (!_coreReady) return;
+			var p = Convert.ToBase64String(Encoding.UTF8.GetBytes(prefix ?? string.Empty));
+			var s = Convert.ToBase64String(Encoding.UTF8.GetBytes(suffix ?? string.Empty));
+			_webView.CoreWebView2.ExecuteScriptAsync($"window.insertAroundSelection(atob('{p}'), atob('{s}'));void(0);");
+		}
+
+		public void InsertSnippet(string snippet)
+		{
+			if (!_coreReady) return;
+			var b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(snippet ?? string.Empty));
+			_webView.CoreWebView2.ExecuteScriptAsync($"window.insertSnippet(atob('{b64}'));void(0);");
+		}
+
+		public void InsertHeading(int level)
+		{
+			if (level < 1) level = 1; if (level > 6) level = 6;
+			InsertSnippet("\n" + new string('#', level) + " ");
+		}
+
+		public void InsertBulletList()
+		{
+			InsertSnippet("\n- ");
+		}
+
+		public void InsertNumberedList()
+		{
+			InsertSnippet("\n1. ");
+		}
+
+		public void InsertCheckbox(bool isChecked)
+		{
+			InsertSnippet(isChecked ? "\n- [x] " : "\n- [ ] ");
+		}
+
+		public void InsertTable(int rows, int cols)
+		{
+			if (rows < 2) rows = 2; if (cols < 2) cols = 2;
+			var sb = new StringBuilder();
+			// header
+			for (int c = 0; c < cols; c++) sb.Append("| Header").Append(c + 1).Append(' ');
+			sb.AppendLine("|");
+			for (int c = 0; c < cols; c++) sb.Append("| --- ");
+			sb.AppendLine("|");
+			for (int r = 0; r < rows - 1; r++)
+			{
+				for (int c = 0; c < cols; c++) sb.Append("| cell ");
+				sb.AppendLine("|");
+			}
+			InsertSnippet("\n" + sb.ToString() + "\n");
+		}
+
+		public void InsertLink(string text, string url)
+		{
+			InsertSnippet($"[{text}]({url})");
+		}
+
+		public void InsertImage(string alt, string path)
+		{
+			InsertSnippet($"![{alt}]({path})");
+		}
+
+		public void InsertCodeBlock(string language)
+		{
+			InsertSnippet($"\n```{language}\n\n```\n");
+		}
+
+		public void InsertMermaidSample()
+		{
+			InsertSnippet("\n```mermaid\ngraph TD; A-->B; A-->C; B-->D; C-->D;\n```\n");
+		}
+
+		public void InsertMathSample()
+		{
+			InsertSnippet("\n$$\\int_{0}^{1} x^2 \\; dx = \\tfrac{1}{3}$$\n");
+		}
+
+		public async void OpenMarkdownFile()
+		{
+			using (var dlg = new OpenFileDialog())
+			{
+				dlg.Filter = "Markdown (*.md)|*.md|All files (*.*)|*.*";
+				if (dlg.ShowDialog() == DialogResult.OK)
+				{
+					var text = File.ReadAllText(dlg.FileName, new UTF8Encoding(false));
+					SetMarkdown(text);
+					Services.DocumentSyncService.SaveMarkdownToActiveDocument(Globals.ThisAddIn.Application, text);
+				}
+			}
+		}
+
+		public async void SaveMarkdownFile()
+		{
+			var md = await GetMarkdownAsync();
+			using (var dlg = new SaveFileDialog())
+			{
+				dlg.Filter = "Markdown (*.md)|*.md|All files (*.*)|*.*";
+				dlg.FileName = "document.md";
+				if (dlg.ShowDialog() == DialogResult.OK)
+				{
+					File.WriteAllText(dlg.FileName, md ?? string.Empty, new UTF8Encoding(false));
+					Services.DocumentSyncService.SaveMarkdownToActiveDocument(Globals.ThisAddIn.Application, md ?? string.Empty);
+				}
+			}
+		}
+
+		private string BuildHtmlShell()
+		{
+			return @"<!DOCTYPE html>
+<html>
+<head>
+<meta charset=\"utf-8\" />
+<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\" />
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+<title>Markdown</title>
+<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism.min.css\" />
+<style>
+  html, body { height:100%; margin:0; font-family:Segoe UI, Arial, sans-serif; }
+  .container { display:flex; height:100%; }
+  #editor { width:50%; height:100%; border:none; padding:12px; font-family:Consolas, monospace; font-size:13px; box-sizing:border-box; outline:none; resize:none; border-right:1px solid #ddd; }
+  #preview { width:50%; height:100%; overflow:auto; padding:16px; box-sizing:border-box; }
+  pre { background:#f6f8fa; padding:10px; overflow:auto; }
+  code { font-family:Consolas, monospace; }
+  table { border-collapse: collapse; }
+  table th, table td { border: 1px solid #ccc; padding: 4px 8px; }
+  hr { border:none; border-top:1px solid #ccc; margin:16px 0; }
+</style>
+</head>
+<body>
+<div class=\"container\">
+  <textarea id=\"editor\" placeholder=\"Введите Markdown...\"></textarea>
+  <div id=\"preview\"></div>
+</div>
+<script src=\"https://cdn.jsdelivr.net/npm/dompurify@3.1.0/dist/purify.min.js\"></script>
+<script src=\"https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js\"></script>
+<script src=\"https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js\"></script>
+<script>Prism.plugins.autoloader.languages_path = 'https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/';</script>
+<script src=\"https://cdn.jsdelivr.net/npm/mermaid@10.9.0/dist/mermaid.min.js\"></script>
+<script>mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' });</script>
+<script>window.MathJax = { tex: { inlineMath: [['$', '$'], ['\\\(', '\\\)']] }, svg: { fontCache: 'global' } };</script>
+<script src=\"https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js\"></script>
+<script>
+  const editor = document.getElementById('editor');
+  const preview = document.getElementById('preview');
+
+  function debounce(fn, ms){ let t; return function(){ clearTimeout(t); t = setTimeout(()=>fn.apply(this, arguments), ms); } }
+
+  function postToHost(type, text){
+    try {
+      const b64 = btoa(unescape(encodeURIComponent(text || '')));
+      window.chrome && window.chrome.webview && window.chrome.webview.postMessage(type + '|' + b64);
+    } catch(e) { console.error(e); }
+  }
+
+  function notifyChange(){ postToHost('mdChanged', editor.value); }
+
+  editor.addEventListener('input', debounce(notifyChange, 120));
+
+  window.editorSetValue = function(text){ editor.value = text || ''; notifyChange(); }
+  window.editorGetValue = function(){ return editor.value || ''; }
+
+  window.insertAroundSelection = function(prefix, suffix){
+    prefix = prefix || ''; suffix = suffix || '';
+    const start = editor.selectionStart || 0;
+    const end = editor.selectionEnd || 0;
+    const val = editor.value;
+    const before = val.substring(0, start);
+    const sel = val.substring(start, end);
+    const after = val.substring(end);
+    editor.value = before + prefix + sel + suffix + after;
+    const newPos = (before + prefix + sel + suffix).length;
+    editor.setSelectionRange(newPos, newPos);
+    editor.focus();
+    notifyChange();
+  }
+
+  window.insertSnippet = function(snippet){
+    const pos = editor.selectionStart || 0;
+    const val = editor.value;
+    editor.value = val.substring(0, pos) + snippet + val.substring(pos);
+    const newPos = (val.substring(0, pos) + snippet).length;
+    editor.setSelectionRange(newPos, newPos);
+    editor.focus();
+    notifyChange();
+  }
+
+  window.renderHtml = function(html){
+    try {
+      const clean = DOMPurify.sanitize(html || '', { ADD_ATTR: ['target','rel','class','style','id'] });
+      preview.innerHTML = clean;
+      // Convert mermaid code blocks into divs
+      const mermaidBlocks = preview.querySelectorAll('pre code.language-mermaid');
+      mermaidBlocks.forEach(code => {
+        const pre = code.parentElement;
+        const wrapper = document.createElement('div');
+        wrapper.className = 'mermaid';
+        wrapper.textContent = code.textContent;
+        pre.replaceWith(wrapper);
+      });
+      Prism.highlightAllUnder(preview);
+      if (window.mermaid) {
+        mermaid.init(undefined, preview.querySelectorAll('.mermaid'));
+      }
+      if (window.MathJax && MathJax.typesetPromise) {
+        MathJax.typesetPromise([preview]).catch(err => console.error(err));
+      }
+    } catch(e){ console.error(e); }
+  }
+</script>
+</body>
+</html>";
+		}
+	}
+}

--- a/WordMarkdownAddIn/Properties/AssemblyInfo.cs
+++ b/WordMarkdownAddIn/Properties/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("WordMarkdownAddIn")]
+[assembly: AssemblyDescription("Markdown add-in for Microsoft Word (VSTO)")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("YourCompany")]
+[assembly: AssemblyProduct("WordMarkdownAddIn")]
+[assembly: AssemblyCopyright("Copyright © 2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/WordMarkdownAddIn/Ribbon.cs
+++ b/WordMarkdownAddIn/Ribbon.cs
@@ -1,0 +1,141 @@
+using System;
+using Office = Microsoft.Office.Core;
+
+namespace WordMarkdownAddIn
+{
+	public class MarkdownRibbon : Office.IRibbonExtensibility
+	{
+		private Office.IRibbonUI _ribbon;
+
+		public string GetCustomUI(string ribbonID)
+		{
+			return @"<customUI xmlns=""http://schemas.microsoft.com/office/2009/07/customui"" onLoad=""OnLoad"">
+				<ribbon>
+					<tabs>
+						<tab id=""tabMarkdown"" label=""Markdown"">
+							<group id=""grpFile"" label=""Файл"">
+								<button id=""btnOpen"" label=""Открыть .md"" size=""large"" onAction=""OnOpenMd"" />
+								<button id=""btnSave"" label=""Сохранить .md"" size=""large"" onAction=""OnSaveMd"" />
+								<toggleButton id=""btnPane"" label=""Панель"" size=""normal"" onAction=""OnTogglePane"" />
+							</group>
+							<group id=""grpFormat"" label=""Форматирование"">
+								<button id=""bBold"" label=""Жирный"" onAction=""OnBold"" />
+								<button id=""bItalic"" label=""Курсив"" onAction=""OnItalic"" />
+								<button id=""bStrike"" label=""Зачеркнуть"" onAction=""OnStrike"" />
+								<button id=""bCode"" label=""Код"" onAction=""OnInlineCode"" />
+							</group>
+							<group id=""grpInsert"" label=""Вставка"">
+								<button id=""bH1"" label=""H1"" onAction=""OnH1"" />
+								<button id=""bList"" label=""Список -"" onAction=""OnBulletList"" />
+								<button id=""bNumList"" label=""Список 1."" onAction=""OnNumberList"" />
+								<button id=""bCheckbox"" label=""Чекбокс"" onAction=""OnCheckbox"" />
+								<button id=""bTable"" label=""Таблица"" onAction=""OnTable"" />
+								<button id=""bLink"" label=""Ссылка"" onAction=""OnLink"" />
+								<button id=""bImage"" label=""Изображение"" onAction=""OnImage"" />
+								<button id=""bHR"" label=""Разделитель"" onAction=""OnHr"" />
+								<button id=""bCodeBlock"" label=""Код-блок"" onAction=""OnCodeBlock"" />
+								<button id=""bMermaid"" label=""Mermaid"" onAction=""OnMermaid"" />
+								<button id=""bMath"" label=""Формула"" onAction=""OnMath"" />
+							</group>
+						</tab>
+					</tabs>
+				</ribbon>
+			</customUI>";
+		}
+
+		public void OnLoad(Office.IRibbonUI ribbonUI)
+		{
+			_ribbon = ribbonUI;
+		}
+
+		public void OnTogglePane(Office.IRibbonControl control, bool pressed)
+		{
+			Globals.ThisAddIn.TogglePane();
+		}
+
+		public void OnOpenMd(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.OpenMarkdownFile();
+		}
+
+		public void OnSaveMd(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.SaveMarkdownFile();
+		}
+
+		public void OnBold(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertInline("**", "**");
+		}
+
+		public void OnItalic(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertInline("*", "*");
+		}
+
+		public void OnStrike(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertInline("~~", "~~");
+		}
+
+		public void OnInlineCode(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertInline("`", "`");
+		}
+
+		public void OnH1(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertHeading(1);
+		}
+
+		public void OnBulletList(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertBulletList();
+		}
+
+		public void OnNumberList(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertNumberedList();
+		}
+
+		public void OnCheckbox(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertCheckbox(false);
+		}
+
+		public void OnTable(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertTable(3, 3);
+		}
+
+		public void OnLink(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertLink("текст", "https://example.com");
+		}
+
+		public void OnImage(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertImage("alt", "assets/image.png");
+		}
+
+		public void OnHr(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertSnippet("\n\n---\n\n");
+		}
+
+		public void OnCodeBlock(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertCodeBlock("csharp");
+		}
+
+		public void OnMermaid(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertMermaidSample();
+		}
+
+		public void OnMath(Office.IRibbonControl control)
+		{
+			Globals.ThisAddIn.PaneControl?.InsertMathSample();
+		}
+	}
+}

--- a/WordMarkdownAddIn/Services/DocumentSyncService.cs
+++ b/WordMarkdownAddIn/Services/DocumentSyncService.cs
@@ -1,0 +1,72 @@
+using System;
+using Word = Microsoft.Office.Interop.Word;
+using Office = Microsoft.Office.Core;
+
+namespace WordMarkdownAddIn.Services
+{
+	public static class DocumentSyncService
+	{
+		public const string NamespaceUri = "urn:markdown/source";
+
+		public static string LoadMarkdownFromActiveDocument(Word.Application app)
+		{
+			if (app == null || app.ActiveDocument == null) return null;
+			var doc = app.ActiveDocument;
+			Office.CustomXMLPart part = FindExistingPart(doc);
+			if (part == null) return null;
+			try
+			{
+				var node = part.SelectSingleNode("/*[local-name()='markdown']/*[local-name()='content']");
+				if (node != null)
+				{
+					return node.Text;
+				}
+			}
+			catch { }
+			return null;
+		}
+
+		public static void SaveMarkdownToActiveDocument(Word.Application app, string markdown)
+		{
+			if (app == null || app.ActiveDocument == null) return;
+			var doc = app.ActiveDocument;
+			var existing = FindExistingPart(doc);
+			if (existing != null)
+			{
+				existing.Delete();
+			}
+			var xml = BuildXml(markdown ?? string.Empty);
+			doc.CustomXMLParts.Add(xml);
+		}
+
+		private static string BuildXml(string content)
+		{
+			// Wrap markdown in CDATA inside a namespaced root
+			return "<md:markdown xmlns:md='" + NamespaceUri + "'>" +
+				"<md:content><![CDATA[" + content + "]]></md:content>" +
+				"</md:markdown>";
+		}
+
+		private static Office.CustomXMLPart FindExistingPart(Word.Document doc)
+		{
+			try
+			{
+				Office.CustomXMLParts parts = doc.CustomXMLParts;
+				foreach (Office.CustomXMLPart p in parts)
+				{
+					try
+					{
+						var root = p.DocumentElement;
+						if (root != null && string.Equals(root.NamespaceURI, NamespaceUri, StringComparison.OrdinalIgnoreCase))
+						{
+							return p;
+						}
+					}
+					catch { }
+				}
+			}
+			catch { }
+			return null;
+		}
+	}
+}

--- a/WordMarkdownAddIn/Services/MarkdownRenderService.cs
+++ b/WordMarkdownAddIn/Services/MarkdownRenderService.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Text.RegularExpressions;
+using Markdig;
+using System.Net;
+
+namespace WordMarkdownAddIn.Services
+{
+	public class MarkdownRenderService
+	{
+		private readonly MarkdownPipeline _pipeline;
+		private static readonly Regex MermaidPreCodeRegex = new Regex("<pre><code class=\"language-mermaid\">([\\s\\S]*?)</code></pre>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+		public MarkdownRenderService()
+		{
+			_pipeline = new MarkdownPipelineBuilder()
+				.UseAdvancedExtensions()
+				.UsePipeTables()
+				.UseTaskLists()
+				.UseMathematics()
+				.Build();
+		}
+
+		public string RenderToHtml(string markdown)
+		{
+			markdown = markdown ?? string.Empty;
+			var html = Markdown.ToHtml(markdown, _pipeline);
+			html = TransformMermaidBlocks(html);
+			return html;
+		}
+
+		private static string TransformMermaidBlocks(string html)
+		{
+			return MermaidPreCodeRegex.Replace(html, m =>
+			{
+				var inner = m.Groups[1].Value;
+				var decoded = WebUtility.HtmlDecode(inner);
+				return "<div class=\"mermaid\">" + decoded + "</div>";
+			});
+		}
+	}
+}

--- a/WordMarkdownAddIn/ThisAddIn.Designer.cs
+++ b/WordMarkdownAddIn/ThisAddIn.Designer.cs
@@ -1,0 +1,15 @@
+namespace WordMarkdownAddIn
+{
+	partial class ThisAddIn
+	{
+		#region VSTO generated code
+
+		private void InternalStartup()
+		{
+			this.Startup += new System.EventHandler(ThisAddIn_Startup);
+			this.Shutdown += new System.EventHandler(ThisAddIn_Shutdown);
+		}
+
+		#endregion
+	}
+}

--- a/WordMarkdownAddIn/ThisAddIn.cs
+++ b/WordMarkdownAddIn/ThisAddIn.cs
@@ -1,0 +1,66 @@
+using System;
+using Microsoft.Office.Tools;
+using Word = Microsoft.Office.Interop.Word;
+using Office = Microsoft.Office.Core;
+
+namespace WordMarkdownAddIn
+{
+	public partial class ThisAddIn
+	{
+		public static CustomTaskPane MarkdownPane { get; private set; }
+		public static Controls.TaskPaneControl PaneControl { get; private set; }
+
+		private void ThisAddIn_Startup(object sender, EventArgs e)
+		{
+			PaneControl = new Controls.TaskPaneControl();
+			MarkdownPane = this.CustomTaskPanes.Add(PaneControl, "Markdown");
+			MarkdownPane.Visible = true;
+
+			// Load markdown from the document if present
+			try
+			{
+				var md = Services.DocumentSyncService.LoadMarkdownFromActiveDocument(Application);
+				if (!string.IsNullOrEmpty(md))
+				{
+					PaneControl.SetMarkdown(md);
+				}
+			}
+			catch { /* ignore at startup */ }
+
+			// Track Word save to persist current Markdown into CustomXMLPart
+			try
+			{
+				this.Application.DocumentBeforeSave += Application_DocumentBeforeSave;
+			}
+			catch { }
+		}
+
+		private void ThisAddIn_Shutdown(object sender, EventArgs e)
+		{
+			try { this.Application.DocumentBeforeSave -= Application_DocumentBeforeSave; } catch { }
+		}
+
+		private void Application_DocumentBeforeSave(Word.Document Doc, ref bool SaveAsUI, ref bool Cancel)
+		{
+			try
+			{
+				var md = PaneControl?.GetCachedMarkdown() ?? string.Empty;
+				Services.DocumentSyncService.SaveMarkdownToActiveDocument(Application, md);
+			}
+			catch { }
+		}
+
+		protected override Office.IRibbonExtensibility CreateRibbonExtensibilityObject()
+		{
+			return new MarkdownRibbon();
+		}
+
+		public void TogglePane()
+		{
+			if (MarkdownPane != null)
+			{
+				MarkdownPane.Visible = !MarkdownPane.Visible;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Scaffold initial VSTO Word add-in for Markdown editing and live preview.

This PR establishes the foundational architecture and core components (Ribbon UI, WebView2-based editor/preview pane, Markdig rendering, and Markdown storage in `CustomXMLPart`) as the first step towards implementing the full technical specification for the Word Markdown add-in.

---
<a href="https://cursor.com/background-agent?bcId=bc-e230312a-1469-4051-a5d2-f026961a66d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e230312a-1469-4051-a5d2-f026961a66d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

